### PR TITLE
optimize cleaning

### DIFF
--- a/build_menu
+++ b/build_menu
@@ -70,8 +70,8 @@ clang(){
 
 clean(){
   echo "${GREEN}***** Cleaning in Progress *****${STD}"
-  make clean
-  make mrproper
+  make clean -j$(nproc)
+  make mrproper -j$(nproc)
   [ -d "out" ] && rm -rf out
   echo "${GREEN}***** Cleaning Done *****${STD}"
 }


### PR DESCRIPTION
use -j$(nproc) with clean and mrproper for a tine speedup in compiling